### PR TITLE
Make existential types more generic

### DIFF
--- a/existential-types/validations.ts
+++ b/existential-types/validations.ts
@@ -12,11 +12,11 @@ type ErrorMessage = MyError | "allfine"
  * This is needed to have a list of validations with the same input A, but
  * different intermediate values B, for example `Array<Validation<string>>`
  */
-type Validation<A> =
-    (callback: <B>(rawValidation: RawValidation<A, ErrorMessage, B>) => ErrorMessage | null)
-        => ErrorMessage | null
+type Validation<A, Result> =
+    (callback: <B>(rawValidation: RawValidation<A, Result, B>) => Result | null)
+        => Result | null
 
-type MakeValidation = <A, B>(validation: RawValidation<A, ErrorMessage, B>) => Validation<A>
+type MakeValidation = <A, B>(validation: RawValidation<A, ErrorMessage, B>) => Validation<A, ErrorMessage>
 
 const applyTo = <A>(input: A) => <B>(func: (input: A) => B): B => func(input)
 
@@ -28,10 +28,10 @@ const runRawValidation: <A>(toValidate: A) => <B>(validation: RawValidation<A, E
         return preprocessed === null ? null : rawValidation.getResult(preprocessed);
     }
 
-const runValidations: <A>(toValidate: A) => (validations: Array<Validation<A>>) => Array<ErrorMessage | null> =
+const runValidations: <A>(toValidate: A) => (validations: Array<Validation<A, ErrorMessage>>) => Array<ErrorMessage | null> =
     toValidate => validations => validations.map(applyTo(runRawValidation(toValidate)))
 
-const validations: Array<Validation<string>> = [
+const validations: Array<Validation<string, ErrorMessage>> = [
     makeValidation({
         preprocess: s => s[0],
         getResult: first => first === "o" ? { error: "should not start with 'o'" } : "allfine"

--- a/existential-types/validations.ts
+++ b/existential-types/validations.ts
@@ -2,7 +2,7 @@
 
 type RawValidation<A, T, B> = {
     preprocess: (_: A) => B | null
-    getError: (_: B) => T
+    getResult: (_: B) => T
 }
 type MyError = { error: string }
 type ErrorMessage = MyError | "allfine"
@@ -25,7 +25,7 @@ const makeValidation: MakeValidation = applyTo
 const runRawValidation: <A>(toValidate: A) => <B>(validation: RawValidation<A, ErrorMessage, B>) => ErrorMessage | null =
     toValidate => rawValidation => {
         const preprocessed = rawValidation.preprocess(toValidate);
-        return preprocessed === null ? null : rawValidation.getError(preprocessed);
+        return preprocessed === null ? null : rawValidation.getResult(preprocessed);
     }
 
 const runValidations: <A>(toValidate: A) => (validations: Array<Validation<A>>) => Array<ErrorMessage | null> =
@@ -34,11 +34,11 @@ const runValidations: <A>(toValidate: A) => (validations: Array<Validation<A>>) 
 const validations: Array<Validation<string>> = [
     makeValidation({
         preprocess: s => s[0],
-        getError: first => first === "o" ? { error: "should not start with 'o'" } : "allfine"
+        getResult: first => first === "o" ? { error: "should not start with 'o'" } : "allfine"
     }),
     makeValidation({
         preprocess: s => s.length,
-        getError: len => len > 3 ? { error: "too long" } : "allfine"
+        getResult: len => len > 3 ? { error: "too long" } : "allfine"
     })
 ]
 

--- a/existential-types/validations.ts
+++ b/existential-types/validations.ts
@@ -22,7 +22,7 @@ const applyTo = <A>(input: A) => <B>(func: (input: A) => B): B => func(input)
 
 const makeValidation: MakeValidation = applyTo
 
-const runRawValidation: <A>(toValidate: A) => <B>(validation: RawValidation<A, ErrorMessage, B>) => ErrorMessage | null =
+const runRawValidation: <A>(toValidate: A) => <Result, B>(validation: RawValidation<A, Result, B>) => Result | null =
     toValidate => rawValidation => {
         const preprocessed = rawValidation.preprocess(toValidate);
         return preprocessed === null ? null : rawValidation.getResult(preprocessed);

--- a/existential-types/validations.ts
+++ b/existential-types/validations.ts
@@ -28,7 +28,7 @@ const runRawValidation: <A>(toValidate: A) => <Result, B>(validation: RawValidat
         return preprocessed === null ? null : rawValidation.getResult(preprocessed);
     }
 
-const runValidations: <A>(toValidate: A) => (validations: Array<Validation<A, ErrorMessage>>) => Array<ErrorMessage | null> =
+const runValidations: <A>(toValidate: A) => <Result>(validations: Array<Validation<A, Result>>) => Array<Result | null> =
     toValidate => validations => validations.map(applyTo(runRawValidation(toValidate)))
 
 const validations: Array<Validation<string, ErrorMessage>> = [

--- a/existential-types/validations.ts
+++ b/existential-types/validations.ts
@@ -16,7 +16,7 @@ type Validation<A, Result> =
     (callback: <B>(rawValidation: RawValidation<A, Result, B>) => Result | null)
         => Result | null
 
-type MakeValidation = <A, B>(validation: RawValidation<A, ErrorMessage, B>) => Validation<A, ErrorMessage>
+type MakeValidation = <A, Result, B>(validation: RawValidation<A, Result, B>) => Validation<A, Result>
 
 const applyTo = <A>(input: A) => <B>(func: (input: A) => B): B => func(input)
 


### PR DESCRIPTION
This removes the hard-coded `ErrorMessage` from the more general parts of the Validation/existential types implementation, to show, that most of the functions can be unaware of the final return type.